### PR TITLE
Remove wrought iron nuggets

### DIFF
--- a/kubejs/server_scripts/gregtech/recipes.removes.js
+++ b/kubejs/server_scripts/gregtech/recipes.removes.js
@@ -1,4 +1,4 @@
-﻿// priority: 0
+// priority: 0
 
 function removeGTCEURecipes(event) {
 
@@ -186,6 +186,12 @@ function removeGTCEURecipes(event) {
 	event.remove({ id: 'gtceu:extractor/fish_oil_from_salmon' })
 	event.remove({ id: 'gtceu:extractor/fish_oil_from_pufferfish' })
 	event.remove({ id: 'gtceu:extractor/fish_oil_from_cod' })
+
+	// #endregion
+
+	// #region Wrought Iron Nugget
+
+	event.remove({ output: 'gtceu:wrought_iron_nugget', type: 'minecraft:smelting' })
 
 	// #endregion
 


### PR DESCRIPTION
Remove the recipe to make wrought iron nuggets from smelting cast iron nuggets


## What is the new behavior?
Nerfing the easy way to make wrought iron by going through nuggets

## Implementation Details
Remove the smelting recipe